### PR TITLE
Filter options

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -8,3 +8,12 @@ Processing ECoG stored in the NWB format
 ECoG data stored in the Neurodata Without Borders (NWB) format. It
 contains low-level signal processing routines and wrapper functions to interface
 with the NWB format.
+
+These functions can be used individually but they are also packaged into an executable script
+`preprocess_folder`. This can be used to preprocess all nwb files in a given folder. Preprocessing
+consists of
+- downsampling the original signal (to 400 Hz by default) and storing this new signal in the file,
+- notch filter for 60 Hz linenoise and calculate, store, and remove a common average reference (mean of 95% by default), the new signal is stored
+- calculate the amplitudes for a filterbank of wavelets, by default constant-Q and log-spaced center frequencies. By default, only the amplitudes are stored.
+
+Run `preprocess_foler -h` for options.

--- a/process_nwb/wavelet_transform.py
+++ b/process_nwb/wavelet_transform.py
@@ -35,8 +35,7 @@ def hamming(n_time, rate, min_freq, max_freq):
     return k
 
 
-def wavelet_transform(X, rate, filters='default', X_fft_h=None, npad=None,
-                      constant_Q=True):
+def wavelet_transform(X, rate, filters='rat', hg_only=True, X_fft_h=None, npad=None):
     """
     Apply bandpass filtering with wavelet transform using
     a prespecified set of filters.
@@ -67,26 +66,30 @@ def wavelet_transform(X, rate, filters='default', X_fft_h=None, npad=None,
         n_time = X_fft_h.shape[0]
     freq = fftfreq(n_time, 1. / rate)
 
-    if filters == 'default':
-        filters = []
+    # Calculate center frequencies
+    if filters in ['human', 'changlab']:
         cfs = log_spaced_cfs(4.0749286538265, 200, 40)
-        if constant_Q:
-            sds = const_Q_sds(cfs)
-        else:
-            raise NotImplementedError
-        for cf, sd in zip(cfs, sds):
-            filters.append(gaussian(n_time, rate, cf, sd))
-    elif filters == 'chang':
-        filters = []
-        cfs = log_spaced_cfs(4.0749286538265, 200, 40)
-        sds = chang_sds(cfs)
-        for cf, sd in zip(cfs, sds):
-            filters.append(gaussian(n_time, rate, cf, sd))
+    elif filters == 'rat':
+        cfs = log_spaced_cfs(2.6308, 1200., 54)
     else:
         raise NotImplementedError
 
-    if not isinstance(filters, list):
-        filters = [filters]
+    # Subselect high gamma bands
+    if hg_only:
+        idxs = np.logical_and(cfs >= 70., cfs <= 150.)
+        cfs = cfs[idxs]
+
+    # Calculate bandwidths
+    if filters in ['rat', 'human']:
+        sds = const_Q_sds(cfs)
+    elif filters == 'changlab':
+        sds = chang_sds(cfs)
+    else:
+        raise NotImplementedError
+
+    filters = []
+    for cf, sd in zip(cfs, sds):
+        filters.append(gaussian(n_time, rate, cf, sd))
 
     Xh = np.zeros(X.shape + (len(filters),), dtype=np.complex)
     if X_fft_h is None:
@@ -105,11 +108,11 @@ def wavelet_transform(X, rate, filters='default', X_fft_h=None, npad=None,
 
     Xh = _trim(Xh, to_removes)
 
-    return Xh, X_fft_h
+    return Xh, X_fft_h, cfs, sds
 
 
-def store_wavelet_transform(elec_series, processing, npad=None, filters='default',
-                            X_fft_h=None, abs_only=True, constant_Q=True):
+def store_wavelet_transform(elec_series, processing, npad=None, filters='rat',
+                            X_fft_h=None, abs_only=True, hg_only=True):
     """
     Apply bandpass filtering with wavelet transform using
     a prespecified set of filters.
@@ -122,20 +125,26 @@ def store_wavelet_transform(elec_series, processing, npad=None, filters='default
         Number of samples per second.
     filters : filter or list of filters (optional)
         One or more bandpass filters
+    X_fft_h : ndarray (n_time, n_channels)
+        Precomputed product of X_fft and heavyside.
+    abs_only : bool
+        If True, only the amplitude is stored.
+    hg_only : bool
+        If True, only the amplitudes in the high gamma range is computed.
 
     Returns
     -------
     Xh : ndarray, complex
         Bandpassed analytic signal
     X_fft_h : ndarray, complex
-        Product of X_ff and heavyside.
+        Product of X_fft and heavyside.
     """
     X = elec_series.data[:]
     rate = elec_series.rate
     if npad is None:
         npad = int(rate)
-    X_wvlt, _ = wavelet_transform(X, rate, filters=filters, X_fft_h=X_fft_h,
-                                  npad=npad, constant_Q=constant_Q)
+    X_wvlt, _, cfs, sds = wavelet_transform(X, rate, filters=filters, X_fft_h=X_fft_h,
+                                            hg_only=hg_only, npad=npad)
     elec_series_wvlt_amp = DecompositionSeries('wvlt_amp_' + elec_series.name,
                                                abs(X_wvlt),
                                                metric='amplitude',
@@ -157,15 +166,9 @@ def store_wavelet_transform(elec_series, processing, npad=None, filters='default
         series.append(elec_series_wvlt_phase)
 
     for es in series:
-        if filters == 'default':
-            cfs = log_spaced_cfs(4.0749286538265, 200, 40)
-            if constant_Q:
-                sds = const_Q_sds(cfs)
-            else:
-                raise NotImplementedError
-            for ii, (cf, sd) in enumerate(zip(cfs, sds)):
-                es.add_band(band_name=str(ii), band_mean=cf,
-                            band_stdev=sd, band_limits=(-1, -1))
+        for ii, (cf, sd) in enumerate(zip(cfs, sds)):
+            es.add_band(band_name=str(ii), band_mean=cf,
+                        band_stdev=sd, band_limits=(-1, -1))
 
         processing.add(es)
     return X_wvlt, series

--- a/process_nwb/wavelet_transform.py
+++ b/process_nwb/wavelet_transform.py
@@ -46,8 +46,15 @@ def wavelet_transform(X, rate, filters='rat', hg_only=True, X_fft_h=None, npad=N
         Input data, dimensions
     rate : float
         Number of samples per second.
-    filters : filter or list of filters (optional)
-        One or more bandpass filters
+    filters : str (optional)
+        Which type of filters to use. Options are
+        'rat': center frequencies spanning 2-1200 Hz, constant Q, 54 bands
+        'human': center frequencies spanning 4-200 Hz, constant Q, 40 bands
+        'changlab': center frequencies spanning 4-200 Hz, variable Q, 40 bands
+    hg_only : bool
+        If True, only the amplitudes in the high gamma range [70-150 Hz] is computed.
+    X_fft_h : ndarray (n_time, n_channels)
+        Precomputed product of X_fft and heavyside.
 
     Returns
     -------
@@ -112,7 +119,7 @@ def wavelet_transform(X, rate, filters='rat', hg_only=True, X_fft_h=None, npad=N
 
 
 def store_wavelet_transform(elec_series, processing, npad=None, filters='rat',
-                            X_fft_h=None, abs_only=True, hg_only=True):
+                            hg_only=True, X_fft_h=None, abs_only=True):
     """
     Apply bandpass filtering with wavelet transform using
     a prespecified set of filters.
@@ -123,14 +130,17 @@ def store_wavelet_transform(elec_series, processing, npad=None, filters='rat',
         Input data, dimensions
     rate : float
         Number of samples per second.
-    filters : filter or list of filters (optional)
-        One or more bandpass filters
+    filters : str (optional)
+        Which type of filters to use. Options are
+        'rat': center frequencies spanning 2-1200 Hz, constant Q, 54 bands
+        'human': center frequencies spanning 4-200 Hz, constant Q, 40 bands
+        'changlab': center frequencies spanning 4-200 Hz, variable Q, 40 bands
+    hg_only : bool
+        If True, only the amplitudes in the high gamma range [70-150 Hz] is computed.
     X_fft_h : ndarray (n_time, n_channels)
         Precomputed product of X_fft and heavyside.
     abs_only : bool
         If True, only the amplitude is stored.
-    hg_only : bool
-        If True, only the amplitudes in the high gamma range is computed.
 
     Returns
     -------

--- a/scripts/preprocess_folder
+++ b/scripts/preprocess_folder
@@ -15,13 +15,16 @@ parser = argparse.ArgumentParser(description='Preprocess nwbs in a folder.' +
                                  '\n3) Perform and store a wavelet decomposition.')
 parser.add_argument('folder', type=str, help='Folder')
 parser.add_argument('--frequency', type=float, default=400., help='Frequency to resample to.')
-parser.add_argument('--filters', type=str, default='default',
+parser.add_argument('--filters', type=str, default='rat',
+                    choices=['rat', 'human', 'changlab'],
                     help='Type of filter bank to use for wavelets.')
+parser.add_argument('--all_filters', action='store_false')
 args = parser.parse_args()
 
 folder = args.folder
 frequency = args.frequency
 filters = args.filters
+hg_only = ~args.all_filters
 
 files = glob.glob(os.path.join(folder, '*.nwb'))
 for fname in files:
@@ -43,7 +46,8 @@ for fname in files:
 
         _, electrical_series_wvlt = store_wavelet_transform(electrical_series_CAR,
                                                             nwbfile.processing['preprocessing'],
-                                                            filters=filters)
+                                                            filters=filters,
+                                                            hg_only=hg_only)
         del _
 
         io.write(nwbfile)

--- a/tests/test_wavelet_transform.py
+++ b/tests/test_wavelet_transform.py
@@ -1,18 +1,25 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+import pytest
 
 from process_nwb.wavelet_transform import (wavelet_transform,
                                            gaussian,
                                            hamming)
 
 
-def test_wavelet_return():
+@pytest.mark.parametrize("filters,hg_only,dim", [('human', False, 40),
+                                                 ('human', True, 8),
+                                                 ('changlab', False, 40),
+                                                 ('changlab', True, 8),
+                                                 ('rat', False, 54),
+                                                 ('rat', True, 6)])
+def test_wavelet_return(filters, hg_only, dim):
     """Test the return shape and dtype.
     """
     X = np.random.randn(1000, 32)
     rate = 200
-    Xh, _ = wavelet_transform(X, rate)
-    assert Xh.shape == (X.shape[0], X.shape[1], 40)
+    Xh, _, cfs, sds = wavelet_transform(X, rate, filters=filters, hg_only=hg_only)
+    assert Xh.shape == (X.shape[0], X.shape[1], dim)
     assert Xh.dtype == np.complex
 
 
@@ -30,3 +37,6 @@ def test_hamming_kernel():
     ker = hamming(1111, 200, 50, 60)
     assert_allclose(np.linalg.norm(ker), 1)
     assert_equal(ker >= 0., True)
+    """
+                                                  , ,
+                                                  """


### PR DESCRIPTION
Make center frequency, Q, and frequnecy range selection simpler.

Now `filters` defines the base set of center frequencies and Q.
- `rat` is 2-1200 Hz, 54 bands, constant Q
- `human` is 4-200 Hz, 40 bands, constant Q
- `changlab` is 4-200 Hz, 40 bands, variable Q

 `hg_only` restricts center frequencies to HG range.

Closes #13 
Closes #4 