### PR TITLE
Changed to dtype=complex64

### DIFF
--- a/process_nwb/wavelet_transform.py
+++ b/process_nwb/wavelet_transform.py
@@ -141,7 +141,7 @@ def wavelet_transform(X, rate, filters='rat', hg_only=True, X_fft_h=None, npad=1
     for cf, sd in zip(cfs, sds):
         filters.append(gaussian(n_time, rate, cf, sd))
 
-    Xh = np.zeros(X.shape + (len(filters),), dtype=np.complex)
+    Xh = np.zeros(X.shape + (len(filters),), dtype=np.complex64)
     if X_fft_h is None:
         # Heavyside filter with 0 DC
         h = np.zeros(len(freq))


### PR DESCRIPTION
Simple fix that should save 2x in memory during calculation. As a simple check for complex64's, I computed the wavelet transform for a signal, n drawn from N(0, 1) and another signal x = 100*unit_step + n for both 128 and 64 precision. In both cases, the absolute difference between 128 and 64 was < 1e-6, so I think we should be fine with 64.